### PR TITLE
Feature: Add Wifi and MQTT status to metrics

### DIFF
--- a/docs/sample-responses/plug-s/settings.json
+++ b/docs/sample-responses/plug-s/settings.json
@@ -1,0 +1,117 @@
+{
+  "device": {
+    "type": "SHPLG-S",
+    "mac": "112233AABCCD <REDACTED>",
+    "hostname": "shellyplug-s-11AA22 <REDACTED>",
+    "num_outputs": 1,
+    "num_meters": 1
+  },
+  "wifi_ap": {
+    "enabled": false,
+    "ssid": "shellyplug-s-11AA22 <REDACTED>",
+    "key": ""
+  },
+  "wifi_sta": {
+    "enabled": true,
+    "ssid": "wifi-ssid <REDACTED>",
+    "ipv4_method": "dhcp",
+    "ip": null,
+    "gw": null,
+    "mask": null,
+    "dns": null
+  },
+  "wifi_sta1": {
+    "enabled": false,
+    "ssid": null,
+    "ipv4_method": "dhcp",
+    "ip": null,
+    "gw": null,
+    "mask": null,
+    "dns": null
+  },
+  "ap_roaming": {
+    "enabled": false,
+    "threshold": -70
+  },
+  "mqtt": {
+    "enable": false,
+    "server": "123.123.123.123:1883 <REDACTED>",
+    "user": "",
+    "id": "shellyplug-s-11AA22 <REDACTED>",
+    "reconnect_timeout_max": 60.000000,
+    "reconnect_timeout_min": 2.000000,
+    "clean_session": true,
+    "keep_alive": 60,
+    "max_qos": 0,
+    "retain": false,
+    "update_period": 30
+  },
+  "coiot": {
+    "enabled": true,
+    "update_period": 15,
+    "peer": ""
+  },
+  "sntp": {
+    "server": "time.google.com",
+    "enabled": true
+  },
+  "login": {
+    "enabled": true,
+    "unprotected": false,
+    "username": "username <REDACTED>"
+  },
+  "pin_code": "",
+  "name": "Router",
+  "fw": "20230503-101129/v1.13.0-g9aed950",
+  "discoverable": false,
+  "build_info": {
+    "build_id": "20230503-101129/v1.13.0-g9aed950",
+    "build_timestamp": "2023-05-03T10:11:29Z",
+    "build_version": "1.0"
+  },
+  "cloud": {
+    "enabled": true,
+    "connected": true
+  },
+  "timezone": "Europe/Berlin",
+  "lat": 49.865711,
+  "lng": 8.626040,
+  "tzautodetect": true,
+  "tz_utc_offset": 7200,
+  "tz_dst": false,
+  "tz_dst_auto": true,
+  "time": "15:30",
+  "unixtime": 1686231022,
+  "led_status_disable": true,
+  "debug_enable": false,
+  "allow_cross_origin": false,
+  "actions": {
+    "active": false,
+    "names": [
+      "btn_on_url",
+      "out_on_url",
+      "out_off_url"
+    ]
+  },
+  "hwinfo": {
+    "hw_revision": "prod-190516",
+    "batch_id": 1
+  },
+  "max_power": 1800,
+  "led_power_disable": true,
+  "relays": [
+    {
+      "name": null,
+      "appliance_type": "General",
+      "ison": true,
+      "has_timer": false,
+      "default_state": "on",
+      "auto_on": 0.00,
+      "auto_off": 0.00,
+      "schedule": false,
+      "schedule_rules": [],
+      "max_power": 1800
+    }
+  ],
+  "eco_mode_enabled": true
+}

--- a/docs/sample-responses/plug-s/shelly.json
+++ b/docs/sample-responses/plug-s/shelly.json
@@ -1,0 +1,9 @@
+{
+  "type": "SHPLG-S",
+  "mac": "112233AABCCD <REDACTED>",
+  "auth": true,
+  "fw": "20230503-101129/v1.13.0-g9aed950",
+  "discoverable": false,
+  "num_outputs": 1,
+  "num_meters": 1
+}

--- a/docs/sample-responses/plug-s/status.json
+++ b/docs/sample-responses/plug-s/status.json
@@ -1,0 +1,67 @@
+{
+  "wifi_sta": {
+    "connected": true,
+    "ssid": "wifi-ssid <REDACTED>",
+    "ip": "123.123.123.123 <REDACTED>",
+    "rssi": -40
+  },
+  "cloud": {
+    "enabled": true,
+    "connected": true
+  },
+  "mqtt": {
+    "connected": false
+  },
+  "time": "15:30",
+  "unixtime": 1686231037,
+  "serial": 5913,
+  "has_update": false,
+  "mac": "112233AABCCD <REDACTED>",
+  "cfg_changed_cnt": 0,
+  "actions_stats": {
+    "skipped": 0
+  },
+  "relays": [
+    {
+      "ison": true,
+      "has_timer": false,
+      "timer_started": 0,
+      "timer_duration": 0,
+      "timer_remaining": 0,
+      "overpower": false,
+      "source": "input"
+    }
+  ],
+  "meters": [
+    {
+      "power": 11.95,
+      "overpower": 0.00,
+      "is_valid": true,
+      "timestamp": 1686238237,
+      "counters": [
+        12.244,
+        12.114,
+        12.657
+      ],
+      "total": 20130
+    }
+  ],
+  "temperature": 31.88,
+  "overtemperature": false,
+  "tmp": {
+    "tC": 31.88,
+    "tF": 89.38,
+    "is_valid": true
+  },
+  "update": {
+    "status": "idle",
+    "has_update": false,
+    "new_version": "20230503-101129/v1.13.0-g9aed950",
+    "old_version": "20230503-101129/v1.13.0-g9aed950"
+  },
+  "ram_total": 52056,
+  "ram_free": 39860,
+  "fs_size": 233681,
+  "fs_free": 166413,
+  "uptime": 103978
+}

--- a/docs/sample-responses/plug/settings.json
+++ b/docs/sample-responses/plug/settings.json
@@ -1,0 +1,116 @@
+{
+  "device": {
+    "type": "SHPLG2-1",
+    "mac": "112233AABCCD <REDACTED>",
+    "hostname": "shellyplug-11AA22 <REDACTED>",
+    "num_outputs": 1,
+    "num_meters": 1
+  },
+  "wifi_ap": {
+    "enabled": false,
+    "ssid": "shellyplug-11AA22 <REDACTED>",
+    "key": ""
+  },
+  "wifi_sta": {
+    "enabled": true,
+    "ssid": "wifi-ssid <REDACTED>",
+    "ipv4_method": "dhcp",
+    "ip": null,
+    "gw": null,
+    "mask": null,
+    "dns": null
+  },
+  "wifi_sta1": {
+    "enabled": false,
+    "ssid": null,
+    "ipv4_method": "dhcp",
+    "ip": null,
+    "gw": null,
+    "mask": null,
+    "dns": null
+  },
+  "ap_roaming": {
+    "enabled": false,
+    "threshold": -70
+  },
+  "mqtt": {
+    "enable": false,
+    "server": "123.123.123.123:1883 <REDACTED>",
+    "user": "",
+    "id": "shellyplug-11AA22 <REDACTED>",
+    "reconnect_timeout_max": 60.000000,
+    "reconnect_timeout_min": 2.000000,
+    "clean_session": true,
+    "keep_alive": 60,
+    "max_qos": 0,
+    "retain": false,
+    "update_period": 30
+  },
+  "coiot": {
+    "enabled": true,
+    "update_period": 15,
+    "peer": ""
+  },
+  "sntp": {
+    "server": "time.google.com",
+    "enabled": true
+  },
+  "login": {
+    "enabled": true,
+    "unprotected": false,
+    "username": "username <REDACTED>"
+  },
+  "pin_code": "",
+  "name": "Waschmaschine",
+  "fw": "20230503-101325/v1.13.0-g9aed950",
+  "discoverable": false,
+  "build_info": {
+    "build_id": "20230503-101325/v1.13.0-g9aed950",
+    "build_timestamp": "2023-05-03T10:13:25Z",
+    "build_version": "1.0"
+  },
+  "cloud": {
+    "enabled": true,
+    "connected": true
+  },
+  "timezone": "Europe/Berlin",
+  "lat": 49.865711,
+  "lng": 8.626040,
+  "tzautodetect": true,
+  "tz_utc_offset": 7200,
+  "tz_dst": false,
+  "tz_dst_auto": true,
+  "time": "15:27",
+  "unixtime": 1686230839,
+  "led_status_disable": false,
+  "debug_enable": false,
+  "allow_cross_origin": false,
+  "actions": {
+    "active": false,
+    "names": [
+      "btn_on_url",
+      "out_on_url",
+      "out_off_url"
+    ]
+  },
+  "hwinfo": {
+    "hw_revision": "prod-191018",
+    "batch_id": 1
+  },
+  "max_power": 3500,
+  "relays": [
+    {
+      "name": null,
+      "appliance_type": "General",
+      "ison": true,
+      "has_timer": false,
+      "default_state": "on",
+      "auto_on": 0.00,
+      "auto_off": 0.00,
+      "schedule": false,
+      "schedule_rules": [],
+      "max_power": 3500
+    }
+  ],
+  "eco_mode_enabled": true
+}

--- a/docs/sample-responses/plug/shelly.json
+++ b/docs/sample-responses/plug/shelly.json
@@ -1,0 +1,9 @@
+{
+  "type": "SHPLG2-1",
+  "mac": "112233AABCCD <REDACTED>",
+  "auth": true,
+  "fw": "20230503-101325/v1.13.0-g9aed950",
+  "discoverable": false,
+  "num_outputs": 1,
+  "num_meters": 1
+}

--- a/docs/sample-responses/plug/status.json
+++ b/docs/sample-responses/plug/status.json
@@ -1,0 +1,60 @@
+{
+  "wifi_sta": {
+    "connected": true,
+    "ssid": "wifi-ssid <REDACTED>",
+    "ip": "123.123.123.123 <REDACTED>",
+    "rssi": -72
+  },
+  "cloud": {
+    "enabled": true,
+    "connected": true
+  },
+  "mqtt": {
+    "connected": false
+  },
+  "time": "15:27",
+  "unixtime": 1686230867,
+  "serial": 4040,
+  "has_update": false,
+  "mac": "112233AABCCD <REDACTED>",
+  "cfg_changed_cnt": 0,
+  "actions_stats": {
+    "skipped": 0
+  },
+  "relays": [
+    {
+      "ison": true,
+      "has_timer": false,
+      "timer_started": 0,
+      "timer_duration": 0,
+      "timer_remaining": 0,
+      "overpower": false,
+      "source": "input"
+    }
+  ],
+  "meters": [
+    {
+      "power": 0.00,
+      "overpower": 0.00,
+      "is_valid": true,
+      "timestamp": 1686238067,
+      "counters": [
+        0.000,
+        0.000,
+        0.000
+      ],
+      "total": 44960
+    }
+  ],
+  "update": {
+    "status": "idle",
+    "has_update": false,
+    "new_version": "20230503-101325/v1.13.0-g9aed950",
+    "old_version": "20230503-101325/v1.13.0-g9aed950"
+  },
+  "ram_total": 52096,
+  "ram_free": 39704,
+  "fs_size": 233681,
+  "fs_free": 165409,
+  "uptime": 103620
+}

--- a/src/main/kotlin/click/dobel/shelly/exporter/client/api/Settings.kt
+++ b/src/main/kotlin/click/dobel/shelly/exporter/client/api/Settings.kt
@@ -10,20 +10,21 @@ data class Settings(
   @JsonProperty("lng")
   val lng: Double,
   @JsonProperty("led_status_disable")
-  val ledStatusDisable: Boolean,
+  val isStatusLedDisabled: Boolean,
   @JsonProperty("fw")
   val firmwareVersion: String,
 
   @JsonProperty("device")
   val device: Device,
-  @JsonProperty("cloud")
-  val cloud: Cloud,
+
+  @JsonProperty("ap_roaming")
+  val apRoaming: ApRoaming,
 
   // Shelly Plug only
   @JsonProperty("max_power")
   val maxPower: Double?,
   @JsonProperty("led_power_disable")
-  val ledPowerDisable: Boolean?,
+  val isPowerLedDisabled: Boolean?,
 ) {
 
   data class Device(
@@ -39,10 +40,10 @@ data class Settings(
     val meterCount: Int,
   )
 
-  data class Cloud(
+  data class ApRoaming(
     @JsonProperty("enabled")
-    val enabled: Boolean,
-    @JsonProperty("connected")
-    val connected: Boolean
+    val isEnabled: Boolean,
+    @JsonProperty("threshold")
+    val threshold: Int,
   )
 }

--- a/src/main/kotlin/click/dobel/shelly/exporter/client/api/Shelly.kt
+++ b/src/main/kotlin/click/dobel/shelly/exporter/client/api/Shelly.kt
@@ -12,5 +12,5 @@ data class Shelly(
   @JsonProperty("fw")
   val firmwareVersion: String,
   @JsonProperty("longid")
-  val longId: Boolean,
+  val hasLongId: Boolean,
 )

--- a/src/main/kotlin/click/dobel/shelly/exporter/client/api/Status.kt
+++ b/src/main/kotlin/click/dobel/shelly/exporter/client/api/Status.kt
@@ -9,7 +9,6 @@ data class Status(
   @JsonProperty("meters")
   val meters: List<Meter>,
 
-
   @JsonProperty("ram_total")
   val ramTotal: Long,
   @JsonProperty("ram_free")
@@ -27,12 +26,21 @@ data class Status(
   @JsonProperty("update")
   val update: Update,
 
+  @JsonProperty("wifi_sta")
+  val wifiSta: WifiSta,
+
+  @JsonProperty("mqtt")
+  val mqtt: Mqtt,
+
+  @JsonProperty("cloud")
+  val cloud: Cloud,
+
   // Following properties available on Plug S only
   // val temperature: Double?,
   @JsonProperty("overtemperature")
   val overTemperature: Boolean?,
   @JsonProperty("tmp")
-  val temperature: Temperature?
+  val temperature: Temperature?,
 ) {
 
   data class Relay(
@@ -79,7 +87,7 @@ data class Status(
     @JsonProperty("tF")
     val fahrenheit: Double,
     @JsonProperty("is_valid")
-    val isValid: Boolean
+    val isValid: Boolean,
   )
 
   data class Update(
@@ -87,5 +95,28 @@ data class Status(
     val status: String,
     @JsonProperty("has_update")
     val hasUpdate: Boolean,
+  )
+
+  data class WifiSta(
+    @JsonProperty("connected")
+    val isConnected: Boolean,
+    @JsonProperty("ssid")
+    val ssid: String,
+    @JsonProperty("ip")
+    val ip: String,
+    @JsonProperty("rssi")
+    val rssi: Int,
+  )
+
+  data class Mqtt(
+    @JsonProperty("connected")
+    val isConnected: Boolean,
+  )
+
+  data class Cloud(
+    @JsonProperty("enabled")
+    val isEnabled: Boolean,
+    @JsonProperty("connected")
+    val isConnected: Boolean,
   )
 }

--- a/src/main/kotlin/click/dobel/shelly/exporter/metrics/ShellyMetrics.kt
+++ b/src/main/kotlin/click/dobel/shelly/exporter/metrics/ShellyMetrics.kt
@@ -115,15 +115,15 @@ class ShellyMetrics(
       ) { settings(address)?.lng }
 
       gauge(
-        "temperature",
+        "temperature.degrees.celsius", // FIXME: unit should be in base unit, but collides with fahrenheit then
         "Device temperature in degrees celsius.",
-        "degrees.celsius",
+        "",
         tags
       ) { status(address)?.temperature?.celsius }
       gauge(
-        "temperature",
+        "temperature.degrees.fahrenheit", // FIXME: unit should be in base unit, but collides with celsius then
+        "Device temperature in degrees fahrenheit.",
         "",
-        "degrees.fahrenheit",
         tags
       ) { status(address)?.temperature?.fahrenheit }
       boolGauge(
@@ -269,7 +269,7 @@ class ShellyMetrics(
     val counterId = FunctionCounter
       .builder(pre(name), this) { shellyClient.runCatching { func() }.getOrNull().orDefault() }
       .description(description)
-      .baseUnit(baseUnit)
+      .baseUnit(baseUnit.trimToNull())
       .tags(tags)
       .register(meterRegistry).id
 
@@ -288,7 +288,7 @@ class ShellyMetrics(
     val gaugeId = Gauge
       .builder(pre(name), this) { shellyClient.runCatching { func() }.getOrNull().orDefault() }
       .description(description)
-      .baseUnit(baseUnit)
+      .baseUnit(baseUnit.trimToNull())
       .tags(tags)
       .register(meterRegistry).id
 
@@ -335,4 +335,6 @@ class ShellyMetrics(
   private inline fun <AR : Any, R : AR?> catchingWithDefault(default: AR, block: () -> R): AR {
     return catching(block).getOrNull() ?: default
   }
+
+  private fun String?.trimToNull() = if (this.isNullOrBlank()) null else this
 }

--- a/src/main/kotlin/click/dobel/shelly/exporter/metrics/ShellyMetrics.kt
+++ b/src/main/kotlin/click/dobel/shelly/exporter/metrics/ShellyMetrics.kt
@@ -65,12 +65,41 @@ class ShellyMetrics(
         "cloud.enabled",
         "Whether Shelly cloud is enabled.",
         tags
-      ) { settings(address)?.cloud?.enabled }
+      ) { status(address)?.cloud?.isEnabled }
       boolGauge(
         "cloud.connected",
         "Whether Shelly cloud is connected.",
         tags
-      ) { settings(address)?.cloud?.connected }
+      ) { status(address)?.cloud?.isConnected }
+
+      boolGauge(
+        "wifi.connected",
+        "Whether Shelly is connected to WIFI.",
+        tags
+      ) { status(address)?.wifiSta?.isConnected }
+      gauge(
+        "wifi.rssi",
+        "Current Wifi Received Signal Strength Indication (RSSI).",
+        "dbmw",
+        tags
+      ) { status(address)?.wifiSta?.rssi }
+      boolGauge(
+        "wifi.roaming.enabled",
+        "Whether AP roaming is enabled.",
+        tags
+      ) { settings(address)?.apRoaming?.isEnabled }
+      gauge(
+        "wifi.roaming.threshold",
+        "RSSI signal strength value below which the device will periodically scan for better access point.",
+        "dbmw",
+        tags
+      ) { settings(address)?.apRoaming?.threshold }
+
+      boolGauge(
+        "mqtt.connected",
+        "Whether Shelly is connected to MQTT server.",
+        tags
+      ) { status(address)?.mqtt?.isConnected }
 
       gauge(
         "location.latitude",


### PR DESCRIPTION
Adds metrics for 
- WIFI connection status
- WIFI AP roaming settings
- MQTT connection status

Fixes temperature in fahrenheit that never showed up previously

Minor code cleanups

Add example responses for scraped shelly endpoints