### PR TITLE
Fix: Make shelly 3em wifi status optional

### DIFF
--- a/src/main/kotlin/click/dobel/shelly/exporter/ShellyExporterApplication.kt
+++ b/src/main/kotlin/click/dobel/shelly/exporter/ShellyExporterApplication.kt
@@ -7,5 +7,6 @@ import org.springframework.boot.runApplication
 class ShellyExporterApplication
 
 fun main(args: Array<String>) {
+  @Suppress("SpreadOperator")
   runApplication<ShellyExporterApplication>(*args)
 }

--- a/src/main/kotlin/click/dobel/shelly/exporter/client/api/gen2/Gen2ShellyStatus.kt
+++ b/src/main/kotlin/click/dobel/shelly/exporter/client/api/gen2/Gen2ShellyStatus.kt
@@ -97,11 +97,11 @@ data class Temperature(
 
 data class WifiStatus(
   @JsonProperty("sta_ip")
-  val ip: String,
+  val ip: String?,
   @JsonProperty("status")
   val status: String,
   @JsonProperty("ssid")
-  val ssid: String,
+  val ssid: String?,
   @JsonProperty("rssi")
   val rssi: Int,
 )


### PR DESCRIPTION
When Wifi is unused / disconnected, IP address and SSID are null. Since these parameters are unused anyway, make them nullable. Should fix #81 