### PR TITLE
fix: do not require the (unused) 'auth_domain' field in gen 2 deviceinfo

### DIFF
--- a/src/main/kotlin/click/dobel/shelly/exporter/client/api/gen2/Gen2ShellyDeviceInfo.kt
+++ b/src/main/kotlin/click/dobel/shelly/exporter/client/api/gen2/Gen2ShellyDeviceInfo.kt
@@ -22,5 +22,5 @@ data class Gen2ShellyDeviceInfo(
   @JsonProperty("auth_en")
   val authEnabled: Boolean,
   @JsonProperty("auth_domain")
-  val authDomain: String,
+  val authDomain: String?,
 )


### PR DESCRIPTION
should fix #115