### PR TITLE
fix: support null values in the name property of Gen2ShellyDeviceInfo

### DIFF
--- a/src/main/kotlin/click/dobel/shelly/exporter/client/api/gen2/Gen2ShellyDeviceInfo.kt
+++ b/src/main/kotlin/click/dobel/shelly/exporter/client/api/gen2/Gen2ShellyDeviceInfo.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class Gen2ShellyDeviceInfo(
   @JsonProperty("name")
-  val name: String,
+  val name: String?,
   @JsonProperty("id")
   val id: String,
   @JsonProperty("mac")

--- a/src/main/kotlin/click/dobel/shelly/exporter/discovery/ShellyGen2DeviceRegistry.kt
+++ b/src/main/kotlin/click/dobel/shelly/exporter/discovery/ShellyGen2DeviceRegistry.kt
@@ -27,7 +27,7 @@ class ShellyGen2DeviceRegistry(
       ShellyDevice(
         mac = mac,
         address = address,
-        name = name.trim(),
+        name = name?.trim() ?: "",
         type = this.model,
         firmwareVersion = firmwareId
       )


### PR DESCRIPTION
My Shelly returns the following response when calling _/rpc/Shelly.GetDeviceInfo_
```json
{
  "name": null,
  "id": "shellypro3em-fce8c0d8bfd8",
  "mac": "FCE8C0D8BFD8",
  "slot": 1,
  "model": "SPEM-003CEBEU",
  "gen": 2,
  "fw_id": "20250520-083714/1.6.2-gc8a76e2",
  "ver": "1.6.2",
  "app": "Pro3EM",
  "auth_en": false,
  "auth_domain": null,
  "profile": "triphase"
}
```
The property _name_ did not support null values, therefore the response could not be mapped to _Gen2ShellyDeviceInfo_.